### PR TITLE
feat(3): Dashboard overview page with balance card and charts

### DIFF
--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -1,0 +1,167 @@
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+/* Balance card spans full width */
+.balance-card {
+  grid-column: 1 / -1;
+  border-radius: 12px;
+  padding: 1.5rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.balance-card--positive {
+  background: linear-gradient(135deg, #dcfce7, #bbf7d0);
+  border: 1px solid #86efac;
+}
+
+.balance-card--negative {
+  background: linear-gradient(135deg, #fee2e2, #fecaca);
+  border: 1px solid #fca5a5;
+}
+
+.balance-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #374151;
+}
+
+.balance-card-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.balance-card-icon {
+  opacity: 0.6;
+}
+
+.balance-card-amount {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.1;
+}
+
+.balance-card--negative .balance-card-amount {
+  color: #991b1b;
+}
+
+.balance-card--positive .balance-card-amount {
+  color: #166534;
+}
+
+.balance-card-meta {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.875rem;
+  color: #4b5563;
+}
+
+.balance-card-income,
+.balance-card-expense {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.balance-card-income {
+  color: #16a34a;
+}
+
+.balance-card-expense {
+  color: #dc2626;
+}
+
+/* Chart cards */
+.chart-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  border: 1px solid #f1f5f9;
+}
+
+.chart-card--wide {
+  grid-column: 1 / -1;
+}
+
+.chart-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin-bottom: 1rem;
+}
+
+.chart-subtitle {
+  font-size: 0.875rem;
+  color: #64748b;
+  font-weight: 400;
+}
+
+.chart-empty {
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+/* Loading */
+.dashboard-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #64748b;
+  padding: 3rem 0;
+}
+
+.spinner {
+  width: 22px;
+  height: 22px;
+  border: 3px solid #e2e8f0;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.dashboard-error {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  color: #991b1b;
+  font-size: 0.9rem;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .chart-card--wide {
+    grid-column: 1;
+  }
+
+  .balance-card-amount {
+    font-size: 2rem;
+  }
+
+  .balance-card-meta {
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,8 +1,203 @@
+import { useState, useEffect } from 'react';
+import {
+  PieChart, Pie, Cell, Legend, Tooltip,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, ResponsiveContainer,
+} from 'recharts';
+import { TrendingUp, TrendingDown, DollarSign } from 'lucide-react';
+import { api } from '../utils/api';
+import { format, parseISO } from 'date-fns';
+import './Dashboard.css';
+
+const INCOME_COLOR = '#22c55e';
+const EXPENSE_COLOR = '#ef4444';
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+}
+
+function formatMonth(monthStr) {
+  try {
+    return format(parseISO(`${monthStr}-01`), 'MMM yyyy');
+  } catch {
+    return monthStr;
+  }
+}
+
+function BalanceCard({ summary }) {
+  const totalIncome = summary.reduce((s, m) => s + m.income, 0);
+  const totalExpenses = summary.reduce((s, m) => s + m.expenses, 0);
+  const balance = totalIncome - totalExpenses;
+  const positive = balance >= 0;
+
+  return (
+    <div className={`balance-card ${positive ? 'balance-card--positive' : 'balance-card--negative'}`}>
+      <div className="balance-card-header">
+        <span className="balance-card-label">Total Balance</span>
+        <DollarSign size={20} className="balance-card-icon" />
+      </div>
+      <div className="balance-card-amount">{formatCurrency(balance)}</div>
+      <div className="balance-card-meta">
+        <span className="balance-card-income">
+          <TrendingUp size={14} /> {formatCurrency(totalIncome)} income
+        </span>
+        <span className="balance-card-expense">
+          <TrendingDown size={14} /> {formatCurrency(totalExpenses)} expenses
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DonutChart({ summary }) {
+  const currentMonth = summary[summary.length - 1];
+  const hasData = currentMonth && (currentMonth.income > 0 || currentMonth.expenses > 0);
+
+  const data = [
+    { name: 'Income', value: currentMonth?.income || 0 },
+    { name: 'Expenses', value: currentMonth?.expenses || 0 },
+  ].filter((d) => d.value > 0);
+
+  if (!hasData) {
+    return (
+      <div className="chart-card">
+        <h2 className="chart-title">This Month</h2>
+        <div className="chart-empty">No transactions this month</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chart-card">
+      <h2 className="chart-title">
+        This Month
+        {currentMonth && <span className="chart-subtitle"> — {formatMonth(currentMonth.month)}</span>}
+      </h2>
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Pie
+            data={data}
+            cx="50%"
+            cy="50%"
+            innerRadius={65}
+            outerRadius={100}
+            paddingAngle={3}
+            dataKey="value"
+            label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+            labelLine={false}
+          >
+            {data.map((entry) => (
+              <Cell
+                key={entry.name}
+                fill={entry.name === 'Income' ? INCOME_COLOR : EXPENSE_COLOR}
+              />
+            ))}
+          </Pie>
+          <Tooltip formatter={(v) => formatCurrency(v)} />
+          <Legend />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function TrendChart({ summary }) {
+  const hasData = summary.some((m) => m.income > 0 || m.expenses > 0);
+
+  const data = summary.map((m) => ({
+    month: formatMonth(m.month),
+    Income: m.income,
+    Expenses: m.expenses,
+  }));
+
+  if (!hasData) {
+    return (
+      <div className="chart-card chart-card--wide">
+        <h2 className="chart-title">6-Month Trend</h2>
+        <div className="chart-empty">No data yet</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="chart-card chart-card--wide">
+      <h2 className="chart-title">6-Month Trend</h2>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={data} margin={{ top: 8, right: 16, left: 8, bottom: 8 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+          <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+          <YAxis tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`} tick={{ fontSize: 12 }} />
+          <Tooltip formatter={(v) => formatCurrency(v)} />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="Income"
+            stroke={INCOME_COLOR}
+            strokeWidth={2}
+            dot={{ r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="Expenses"
+            stroke={EXPENSE_COLOR}
+            strokeWidth={2}
+            dot={{ r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
 export default function Dashboard() {
+  const [summary, setSummary] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    api.get('/summary')
+      .then((data) => {
+        setSummary(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to load dashboard data');
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="page">
+        <h1 className="page-title">Dashboard</h1>
+        <div className="dashboard-loading">
+          <div className="spinner" />
+          <span>Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page">
+        <h1 className="page-title">Dashboard</h1>
+        <div className="dashboard-error">Unable to load data: {error}</div>
+      </div>
+    );
+  }
+
   return (
     <div className="page">
       <h1 className="page-title">Dashboard</h1>
-      <p className="page-subtitle">Overview of your finances</p>
+      <p className="page-subtitle">Your financial overview at a glance</p>
+
+      <div className="dashboard-grid">
+        <BalanceCard summary={summary} />
+        <DonutChart summary={summary} />
+        <TrendChart summary={summary} />
+      </div>
     </div>
   );
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,4 +11,14 @@ export default defineConfig({
       },
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom', 'react-router-dom'],
+          charts: ['recharts'],
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
Feature #3 for Issue #1

Builds the `/dashboard` page with three components:

1. **Total Balance card** — all-time income minus expenses, green (positive) / red (negative) styling
2. **Donut chart** — `PieChart` with `innerRadius`, income vs expenses for current month, with legend and tooltip
3. **6-month trend** — `LineChart` with income (green) and expense (red) lines, month labels on X axis

Also:
- Loading spinner while fetching
- Error state if API unavailable
- Empty state if no transactions
- Responsive 2-col grid (1-col mobile)
- `vite.config.js` updated with `manualChunks` (vendor + charts) — no build warnings

Part of #1

---
*Created by Antigravity Dev Agent*