### PR TITLE
feat(4): Transactions page with table, add modal, filters, and CSV export

### DIFF
--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,28 @@
+import { X } from 'lucide-react';
+import './Modal.css';
+
+export default function ConfirmDialog({ message, onConfirm, onCancel, loading }) {
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal modal--sm" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">Confirm</h2>
+          <button className="modal-close" onClick={onCancel} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+        <div className="modal-body">
+          <p>{message || 'Are you sure?'}</p>
+        </div>
+        <div className="modal-footer">
+          <button className="btn btn--ghost" onClick={onCancel} disabled={loading}>
+            Cancel
+          </button>
+          <button className="btn btn--danger" onClick={onConfirm} disabled={loading}>
+            {loading ? 'Deleting…' : 'Delete'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Modal.css
+++ b/frontend/src/components/Modal.css
@@ -1,0 +1,196 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 500;
+  padding: 1rem;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.18);
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal--sm {
+  max-width: 360px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem 1rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.modal-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.modal-close {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color 0.15s;
+}
+
+.modal-close:hover {
+  color: #1e293b;
+}
+
+.modal-body {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem 1.25rem;
+  border-top: 1px solid #f1f5f9;
+}
+
+/* Form elements */
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.form-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  color: #1e293b;
+  background: #fff;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.form-input--error {
+  border-color: #ef4444;
+}
+
+.form-error {
+  font-size: 0.8rem;
+  color: #ef4444;
+}
+
+.form-server-error {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.875rem;
+  color: #991b1b;
+}
+
+.form-radio-group {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.form-radio-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: #374151;
+}
+
+/* Buttons */
+.btn {
+  padding: 0.5rem 1.1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: background 0.15s, opacity 0.15s;
+  font-family: inherit;
+  white-space: nowrap;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.btn--danger {
+  background: #ef4444;
+  color: #fff;
+}
+
+.btn--danger:hover:not(:disabled) {
+  background: #dc2626;
+}
+
+.btn--ghost {
+  background: #f1f5f9;
+  color: #374151;
+  border: 1px solid #e2e8f0;
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: #e2e8f0;
+}
+
+.btn--outline {
+  background: transparent;
+  color: #374151;
+  border: 1px solid #d1d5db;
+}
+
+.btn--outline:hover:not(:disabled) {
+  background: #f8fafc;
+}
+
+.btn--sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}

--- a/frontend/src/components/TransactionModal.jsx
+++ b/frontend/src/components/TransactionModal.jsx
@@ -1,0 +1,174 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { format } from 'date-fns';
+import { api } from '../utils/api';
+import './Modal.css';
+
+const CATEGORIES = ['Food', 'Transport', 'Bills', 'Entertainment', 'Shopping', 'Salary', 'Freelance', 'Other'];
+
+const today = () => format(new Date(), 'yyyy-MM-dd');
+
+const EMPTY_FORM = {
+  date: today(),
+  description: '',
+  amount: '',
+  category: '',
+  type: 'expense',
+};
+
+export default function TransactionModal({ onClose, onSuccess }) {
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState(null);
+
+  function validate() {
+    const e = {};
+    if (!form.date || !/^\d{4}-\d{2}-\d{2}$/.test(form.date)) e.date = 'Valid date required (YYYY-MM-DD)';
+    if (!form.description.trim()) e.description = 'Description is required';
+    const amt = parseFloat(form.amount);
+    if (isNaN(amt) || amt <= 0) e.amount = 'Amount must be greater than 0';
+    if (!form.category) e.category = 'Category is required';
+    if (!['income', 'expense'].includes(form.type)) e.type = 'Type is required';
+    return e;
+  }
+
+  function handleChange(e) {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+    setErrors((err) => ({ ...err, [name]: undefined }));
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const errs = validate();
+    if (Object.keys(errs).length) {
+      setErrors(errs);
+      return;
+    }
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      await api.post('/transactions', {
+        date: form.date,
+        description: form.description.trim(),
+        amount: parseFloat(form.amount),
+        category: form.category,
+        type: form.type,
+      });
+      onSuccess();
+    } catch (err) {
+      setServerError(err.data?.errors?.join(', ') || err.message || 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">Add Transaction</h2>
+          <button className="modal-close" onClick={onClose} aria-label="Close">
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="modal-body">
+            {serverError && <div className="form-server-error">{serverError}</div>}
+
+            <div className="form-field">
+              <label className="form-label" htmlFor="txn-date">Date</label>
+              <input
+                id="txn-date"
+                type="date"
+                name="date"
+                className={`form-input ${errors.date ? 'form-input--error' : ''}`}
+                value={form.date}
+                onChange={handleChange}
+              />
+              {errors.date && <span className="form-error">{errors.date}</span>}
+            </div>
+
+            <div className="form-field">
+              <label className="form-label" htmlFor="txn-desc">Description</label>
+              <input
+                id="txn-desc"
+                type="text"
+                name="description"
+                className={`form-input ${errors.description ? 'form-input--error' : ''}`}
+                value={form.description}
+                onChange={handleChange}
+                placeholder="e.g. Grocery shopping"
+                maxLength={120}
+              />
+              {errors.description && <span className="form-error">{errors.description}</span>}
+            </div>
+
+            <div className="form-field">
+              <label className="form-label" htmlFor="txn-amount">Amount ($)</label>
+              <input
+                id="txn-amount"
+                type="number"
+                name="amount"
+                className={`form-input ${errors.amount ? 'form-input--error' : ''}`}
+                value={form.amount}
+                onChange={handleChange}
+                placeholder="0.00"
+                min="0.01"
+                step="0.01"
+              />
+              {errors.amount && <span className="form-error">{errors.amount}</span>}
+            </div>
+
+            <div className="form-field">
+              <label className="form-label" htmlFor="txn-category">Category</label>
+              <select
+                id="txn-category"
+                name="category"
+                className={`form-input ${errors.category ? 'form-input--error' : ''}`}
+                value={form.category}
+                onChange={handleChange}
+              >
+                <option value="">Select category…</option>
+                {CATEGORIES.map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+              {errors.category && <span className="form-error">{errors.category}</span>}
+            </div>
+
+            <div className="form-field">
+              <span className="form-label">Type</span>
+              <div className="form-radio-group">
+                {['income', 'expense'].map((t) => (
+                  <label key={t} className="form-radio-label">
+                    <input
+                      type="radio"
+                      name="type"
+                      value={t}
+                      checked={form.type === t}
+                      onChange={handleChange}
+                    />
+                    <span>{t.charAt(0).toUpperCase() + t.slice(1)}</span>
+                  </label>
+                ))}
+              </div>
+              {errors.type && <span className="form-error">{errors.type}</span>}
+            </div>
+          </div>
+
+          <div className="modal-footer">
+            <button type="button" className="btn btn--ghost" onClick={onClose} disabled={submitting}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn--primary" disabled={submitting}>
+              {submitting ? 'Saving…' : 'Add Transaction'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Transactions.css
+++ b/frontend/src/pages/Transactions.css
@@ -1,0 +1,259 @@
+.txn-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+
+.txn-actions {
+  display: flex;
+  gap: 0.625rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.txn-actions .btn {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.txn-filters {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.filter-select {
+  padding: 0.45rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: #374151;
+  background: #fff;
+  cursor: pointer;
+  min-width: 150px;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.txn-error {
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: #991b1b;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+/* Table */
+.txn-table-wrap {
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  overflow-x: auto;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.txn-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.txn-th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+}
+
+.txn-th--sortable {
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.txn-th--sortable:hover {
+  color: #1e293b;
+}
+
+.txn-th--right {
+  text-align: right;
+  justify-content: flex-end;
+}
+
+.txn-th--action {
+  width: 48px;
+}
+
+.sort-icon {
+  flex-shrink: 0;
+}
+
+.sort-icon--inactive {
+  opacity: 0.4;
+}
+
+.sort-icon--active {
+  color: #3b82f6;
+}
+
+.txn-row:hover {
+  background: #f8fafc;
+}
+
+.txn-row + .txn-row .txn-cell {
+  border-top: 1px solid #f1f5f9;
+}
+
+.txn-cell {
+  padding: 0.75rem 1rem;
+  color: #1e293b;
+  vertical-align: middle;
+  border-top: 1px solid #f1f5f9;
+}
+
+.txn-cell--center {
+  text-align: center;
+  padding: 2.5rem;
+  color: #64748b;
+}
+
+.txn-cell--muted {
+  color: #94a3b8;
+}
+
+.txn-cell--right {
+  text-align: right;
+}
+
+.txn-cell--desc {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.txn-cell--amount {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.txn-cell--income {
+  color: #16a34a;
+}
+
+.txn-cell--expense {
+  color: #dc2626;
+}
+
+.txn-cell--action {
+  padding: 0.5rem;
+  width: 48px;
+}
+
+/* Badges */
+.txn-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
+.txn-badge--category {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.txn-badge--type {
+  text-transform: capitalize;
+}
+
+.txn-badge--income {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.txn-badge--expense {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+/* Delete button */
+.txn-delete-btn {
+  color: #94a3b8;
+  padding: 0.35rem;
+}
+
+.txn-delete-btn:hover:not(:disabled) {
+  color: #ef4444;
+  background: #fee2e2;
+  border-color: #fecaca;
+}
+
+/* Pagination */
+.txn-pagination {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1.25rem;
+}
+
+.txn-page-info {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+/* Inline loading spinner */
+.spinner-sm {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid #e2e8f0;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  vertical-align: middle;
+  margin-right: 0.5rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .txn-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .txn-actions {
+    justify-content: flex-end;
+  }
+
+  .txn-cell--desc {
+    max-width: 120px;
+  }
+}

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -1,8 +1,283 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Plus, Download, Trash2, ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
+import { format, parseISO } from 'date-fns';
+import { api } from '../utils/api';
+import { exportTransactionsCSV } from '../utils/csvExport';
+import TransactionModal from '../components/TransactionModal';
+import ConfirmDialog from '../components/ConfirmDialog';
+import './Transactions.css';
+
+const CATEGORIES = ['Food', 'Transport', 'Bills', 'Entertainment', 'Shopping', 'Salary', 'Freelance', 'Other'];
+const PAGE_SIZE = 20;
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+}
+
+function formatDate(dateStr) {
+  try { return format(parseISO(dateStr), 'MMM d, yyyy'); } catch { return dateStr; }
+}
+
+function SortIcon({ field, sortField, sortDir }) {
+  if (sortField !== field) return <ChevronsUpDown size={14} className="sort-icon sort-icon--inactive" />;
+  return sortDir === 'asc'
+    ? <ChevronUp size={14} className="sort-icon sort-icon--active" />
+    : <ChevronDown size={14} className="sort-icon sort-icon--active" />;
+}
+
 export default function Transactions() {
+  const [transactions, setTransactions] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Filters
+  const [filterCategory, setFilterCategory] = useState('');
+  const [filterType, setFilterType] = useState('');
+
+  // Sort (client-side on current page)
+  const [sortField, setSortField] = useState('date');
+  const [sortDir, setSortDir] = useState('desc');
+
+  // Modal state
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState(null); // { id, description }
+  const [deleting, setDeleting] = useState(false);
+
+  // CSV export state
+  const [exporting, setExporting] = useState(false);
+
+  const fetchTransactions = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({ page, limit: PAGE_SIZE });
+    if (filterCategory) params.set('category', filterCategory);
+    if (filterType) params.set('type', filterType);
+
+    api.get(`/transactions?${params}`)
+      .then((data) => {
+        setTransactions(data.data);
+        setTotal(data.total);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to load transactions');
+        setLoading(false);
+      });
+  }, [page, filterCategory, filterType]);
+
+  useEffect(() => {
+    fetchTransactions();
+  }, [fetchTransactions]);
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setPage(1);
+  }, [filterCategory, filterType]);
+
+  function handleSort(field) {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  }
+
+  const sortedRows = [...transactions].sort((a, b) => {
+    let av = a[sortField];
+    let bv = b[sortField];
+    if (sortField === 'date') { av = new Date(av); bv = new Date(bv); }
+    if (av < bv) return sortDir === 'asc' ? -1 : 1;
+    if (av > bv) return sortDir === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await api.delete(`/transactions/${deleteTarget.id}`);
+      setDeleteTarget(null);
+      fetchTransactions();
+    } catch (err) {
+      setDeleteTarget(null);
+      setError(err.message || 'Delete failed');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  async function handleExportCSV() {
+    setExporting(true);
+    try {
+      const params = new URLSearchParams({ page: 1, limit: 10000 });
+      const data = await api.get(`/transactions?${params}`);
+      exportTransactionsCSV(data.data);
+    } catch (err) {
+      setError(err.message || 'Export failed');
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
   return (
     <div className="page">
-      <h1 className="page-title">Transactions</h1>
-      <p className="page-subtitle">View and manage your transactions</p>
+      <div className="txn-header">
+        <div>
+          <h1 className="page-title">Transactions</h1>
+          <p className="page-subtitle">{total} transaction{total !== 1 ? 's' : ''} total</p>
+        </div>
+        <div className="txn-actions">
+          <button className="btn btn--outline" onClick={handleExportCSV} disabled={exporting}>
+            <Download size={15} />
+            {exporting ? 'Exporting…' : 'Export CSV'}
+          </button>
+          <button className="btn btn--primary" onClick={() => setShowAddModal(true)}>
+            <Plus size={15} />
+            Add Transaction
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="txn-filters">
+        <select
+          className="filter-select"
+          value={filterCategory}
+          onChange={(e) => setFilterCategory(e.target.value)}
+          aria-label="Filter by category"
+        >
+          <option value="">All Categories</option>
+          {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
+        </select>
+
+        <select
+          className="filter-select"
+          value={filterType}
+          onChange={(e) => setFilterType(e.target.value)}
+          aria-label="Filter by type"
+        >
+          <option value="">All Types</option>
+          <option value="income">Income</option>
+          <option value="expense">Expense</option>
+        </select>
+      </div>
+
+      {error && <div className="txn-error">{error}</div>}
+
+      {/* Table */}
+      <div className="txn-table-wrap">
+        <table className="txn-table">
+          <thead>
+            <tr>
+              <th
+                className="txn-th txn-th--sortable"
+                onClick={() => handleSort('date')}
+              >
+                Date <SortIcon field="date" sortField={sortField} sortDir={sortDir} />
+              </th>
+              <th className="txn-th">Description</th>
+              <th
+                className="txn-th txn-th--sortable txn-th--right"
+                onClick={() => handleSort('amount')}
+              >
+                Amount <SortIcon field="amount" sortField={sortField} sortDir={sortDir} />
+              </th>
+              <th className="txn-th">Category</th>
+              <th className="txn-th">Type</th>
+              <th className="txn-th txn-th--action"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={6} className="txn-cell txn-cell--center">
+                  <span className="spinner-sm" /> Loading…
+                </td>
+              </tr>
+            ) : sortedRows.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="txn-cell txn-cell--center txn-cell--muted">
+                  No transactions found
+                </td>
+              </tr>
+            ) : (
+              sortedRows.map((txn) => (
+                <tr key={txn.id} className="txn-row">
+                  <td className="txn-cell">{formatDate(txn.date)}</td>
+                  <td className="txn-cell txn-cell--desc">{txn.description}</td>
+                  <td className={`txn-cell txn-cell--right txn-cell--amount txn-cell--${txn.type}`}>
+                    {txn.type === 'expense' ? '−' : '+'}{formatCurrency(txn.amount)}
+                  </td>
+                  <td className="txn-cell">
+                    <span className="txn-badge txn-badge--category">{txn.category}</span>
+                  </td>
+                  <td className="txn-cell">
+                    <span className={`txn-badge txn-badge--type txn-badge--${txn.type}`}>
+                      {txn.type}
+                    </span>
+                  </td>
+                  <td className="txn-cell txn-cell--action">
+                    <button
+                      className="btn btn--sm btn--ghost txn-delete-btn"
+                      onClick={() => setDeleteTarget({ id: txn.id, description: txn.description })}
+                      aria-label="Delete transaction"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="txn-pagination">
+        <button
+          className="btn btn--outline btn--sm"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page <= 1 || loading}
+        >
+          Previous
+        </button>
+        <span className="txn-page-info">
+          Page {page} of {totalPages}
+        </span>
+        <button
+          className="btn btn--outline btn--sm"
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page >= totalPages || loading}
+        >
+          Next
+        </button>
+      </div>
+
+      {/* Modals */}
+      {showAddModal && (
+        <TransactionModal
+          onClose={() => setShowAddModal(false)}
+          onSuccess={() => {
+            setShowAddModal(false);
+            fetchTransactions();
+          }}
+        />
+      )}
+
+      {deleteTarget && (
+        <ConfirmDialog
+          message={`Delete "${deleteTarget.description}"? This cannot be undone.`}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleting}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/utils/csvExport.js
+++ b/frontend/src/utils/csvExport.js
@@ -1,0 +1,28 @@
+/**
+ * Exports an array of transaction objects as a CSV download.
+ * Uses Blob + object URL — works in all modern browsers.
+ */
+export function exportTransactionsCSV(transactions, filename = 'transactions.csv') {
+  const headers = ['Date', 'Description', 'Amount', 'Category', 'Type'];
+
+  const rows = transactions.map((t) => [
+    t.date,
+    `"${(t.description || '').replace(/"/g, '""')}"`,
+    t.amount,
+    t.category,
+    t.type,
+  ]);
+
+  const csvContent = [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Feature #4 for Issue #1

Full `/transactions` page implementation:

**Table**
- Columns: Date, Description, Amount (color-coded), Category badge, Type badge, Delete
- Sort by Date or Amount (click header toggles asc/desc)
- Filter by Category and Type via dropdowns

**Pagination**
- 20 rows/page, Previous/Next buttons, page indicator

**Delete**
- `ConfirmDialog` with descriptive message, loading spinner on confirm
- Calls `DELETE /api/transactions/:id`

**Add Transaction Modal** (`TransactionModal`)
- Date picker (defaults to today), description, amount, category dropdown, income/expense radio
- Client-side validation for all fields
- Server error passthrough
- Refreshes table on success

**CSV Export** (`utils/csvExport.js`)
- Fetches all transactions (no filter, limit=10000)
- Generates CSV with `Blob` + `URL.createObjectURL`
- Downloads as `transactions.csv`

`npm run build` passes clean.

Part of #1

---
*Created by Antigravity Dev Agent*